### PR TITLE
Spell validation

### DIFF
--- a/Assets/Prefabs/Dragon.prefab
+++ b/Assets/Prefabs/Dragon.prefab
@@ -238,7 +238,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18cddf289435744319c41ee9e83103ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthbarController: {fileID: 3209577535528806564}
+  healthbarController: {fileID: 0}
   characterName: Dragon
   combatManager: {fileID: 0}
   targetingArrow: {fileID: 5249771350204926493}

--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -345,7 +345,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 18cddf289435744319c41ee9e83103ca, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthbarController: {fileID: 4554269515193734313}
+  healthbarController: {fileID: 0}
   characterName: CJ the gr8
   combatManager: {fileID: 0}
   targetingArrow: {fileID: 8158397805536742570}

--- a/Assets/Scenes/CombatScene.unity
+++ b/Assets/Scenes/CombatScene.unity
@@ -366,6 +366,7 @@ MonoBehaviour:
     type: 3}
   castButton: {fileID: 1041222530}
   cardsRequired: 3
+  selectedCards: []
 --- !u!4 &584664903
 Transform:
   m_ObjectHideFlags: 0
@@ -478,6 +479,7 @@ MonoBehaviour:
   redSprite: {fileID: 21300000, guid: 286f278a9d2be492fb733571efc7279f, type: 3}
   greySprite: {fileID: 21300000, guid: 47ffd528de3c7426ea9e27c0003eb010, type: 3}
   cardsRequired: 3
+  combatManager: {fileID: 0}
 --- !u!61 &1041222531
 BoxCollider2D:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/CardController.cs
+++ b/Assets/Scripts/CardController.cs
@@ -7,6 +7,7 @@ public class CardController : MonoBehaviour {
     public Color32 unselectedColor;
     public Color32 selectedColor;
     public GameObject cardIndexPrefab;
+    public Spell spell;
     CardIndexController cardIndexController;
     SpriteRenderer spriteRenderer;
     bool isSelected;
@@ -28,19 +29,16 @@ public class CardController : MonoBehaviour {
         handController.HandleCardClick (this, isSelected);
     }
 
-    public void SetSelected(bool selected) {
+    public void SetSelected (bool selected) {
         this.isSelected = selected;
     }
 
-    public void UpdateCardDisplay (int newIndex, bool canCast = false) {
+    public void UpdateCardDisplay () {
         // A non-zero index indicates that the card is selected
         spriteRenderer.color = isSelected ? selectedColor : unselectedColor;
-
-        UpdateCardIndexDisplay(newIndex, canCast);
     }
 
-    void UpdateCardIndexDisplay(int newIndex, bool canCast = false) {
-        cardIndexController.UpdateIndex (newIndex);
-        cardIndexController.SetCanCast (canCast);
+    public void UpdateCardIndexDisplay (int newIndex, bool canCast = false) {
+        cardIndexController.UpdateIndexDisplay (newIndex, canCast);
     }
 }

--- a/Assets/Scripts/CardIndexController.cs
+++ b/Assets/Scripts/CardIndexController.cs
@@ -13,10 +13,16 @@ public class CardIndexController : MonoBehaviour {
         textMesh = GetComponent<TextMesh> ();
     }
 
-    public void UpdateIndex (int index) {
-        isDisplayed = index != 0;
-        indexToDisplay = index;
+    public void UpdateIndexDisplay (int index, bool canCast) {
+        SetIsDisplayed (index != -1);
+        UpdateIndex (index);
+        SetCanCast (canCast);
         UpdateText ();
+        UpdateColor ();
+    }
+
+    void UpdateIndex (int index) {
+        indexToDisplay = index;
     }
 
     void UpdateText () {
@@ -27,12 +33,16 @@ public class CardIndexController : MonoBehaviour {
         }
     }
 
-    public void SetCanCast (bool canCast) {
+    void SetIsDisplayed (bool isDisplayed) {
+        this.isDisplayed = isDisplayed;
+    }
+
+    void SetCanCast (bool canCast) {
         this.canCast = canCast;
         UpdateColor ();
     }
 
     void UpdateColor () {
-        textMesh.color = canCast?readyCastColor : unreadyCastColor;
+        textMesh.color = canCast ? readyCastColor : unreadyCastColor;
     }
 }

--- a/Assets/Scripts/CastButtonController.cs
+++ b/Assets/Scripts/CastButtonController.cs
@@ -6,8 +6,8 @@ public class CastButtonController : MonoBehaviour
 {
     public Sprite redSprite;
     public Sprite greySprite;
-
     public int cardsRequired;
+    public CombatManager combatManager;
 
     bool isReady;
     SpriteRenderer spriteRenderer;
@@ -23,8 +23,7 @@ public class CastButtonController : MonoBehaviour
 
     void OnMouseUp() {
         if (isReady) {
-            Debug.Log("cast button clicked");
-            // TODO: CJ - Decrease character health bars
+            combatManager.ExecuteSpell();
         }
     }
 }

--- a/Assets/Scripts/CastButtonController.cs
+++ b/Assets/Scripts/CastButtonController.cs
@@ -2,8 +2,7 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class CastButtonController : MonoBehaviour
-{
+public class CastButtonController : MonoBehaviour {
     public Sprite redSprite;
     public Sprite greySprite;
     public int cardsRequired;
@@ -12,8 +11,8 @@ public class CastButtonController : MonoBehaviour
     bool isReady;
     SpriteRenderer spriteRenderer;
 
-    void Start() {
-        spriteRenderer = GetComponent<SpriteRenderer>();
+    void Start () {
+        spriteRenderer = GetComponent<SpriteRenderer> ();
     }
 
     public void SetReady (bool ready) {
@@ -21,9 +20,9 @@ public class CastButtonController : MonoBehaviour
         spriteRenderer.sprite = isReady ? redSprite : greySprite;
     }
 
-    void OnMouseUp() {
+    void OnMouseUp () {
         if (isReady) {
-            combatManager.ExecuteSpell();
+            combatManager.ExecuteSpell ();
         }
     }
 }

--- a/Assets/Scripts/CombatManager.cs
+++ b/Assets/Scripts/CombatManager.cs
@@ -2,78 +2,68 @@
 using System.Collections.Generic;
 using UnityEngine;
 
-public class CombatManager : MonoBehaviour
-{
+public class CombatManager : MonoBehaviour {
     public GameObject playerPrefab;
     public GameObject enemyPrefab;
-
     public CastButtonController castButton;
-
     public int cardsRequired;
-
+    public List<CardController> selectedCards;
     List<CreatureController> targets;
+    SpellProcessor spellProcessor;
 
-    int cardsSelected;
-
-    void Awake() {
-        targets = new List<CreatureController>();
+    void Awake () {
+        targets = new List<CreatureController> ();
+        selectedCards = new List<CardController> ();
+        spellProcessor = new SpellProcessor ();
     }
 
-    void Start()
-    {
-        GenerateCombatParticipants();
+    void Start () {
+        GenerateCombatParticipants ();
+        castButton.combatManager = this;
     }
 
-    void GenerateCombatParticipants() {
+    void GenerateCombatParticipants () {
         // Instantiate prefabs
-        GenerateCreature(playerPrefab);
-        GenerateCreature(enemyPrefab);
+        GenerateCreature (playerPrefab);
+        GenerateCreature (enemyPrefab);
     }
 
-    void GenerateCreature(GameObject creaturePrefab) {
-        GameObject creature = Instantiate(creaturePrefab);
+    void GenerateCreature (GameObject creaturePrefab) {
+        GameObject creature = Instantiate (creaturePrefab);
 
-        creature.transform.SetParent(gameObject.transform, false);
+        creature.transform.SetParent (gameObject.transform, false);
 
-        creature.GetComponent<CreatureController>().combatManager = this;
+        creature.GetComponent<CreatureController> ().combatManager = this;
     }
 
-    public void HandleCreatureClick(CreatureController creature) {
-
+    public void HandleCreatureClick (CreatureController creature) {
         // Check for target selection and update creature displays accordingly
-        if (targets.Contains(creature)) {
-            targets.Remove(creature);
-
-            creature.SetTargetingArrowDisplay(false);
-
+        if (targets.Contains (creature)) {
+            targets.Remove (creature);
+            creature.SetTargetingArrowDisplay (false);
         } else {
-            targets.Add(creature);
-
-            creature.SetTargetingArrowDisplay(true);
-
+            targets.Add (creature);
+            creature.SetTargetingArrowDisplay (true);
         }
-
         // Update UI if all conditions for casting a spell have been met
-        CheckCastReady();
+        CheckCastReady ();
     }
 
-    public bool ParseSpell(int numCards) {
+    public bool IsSpellValid (List<CardController> selectedCards) {
         // TODO: return true and set ref if cards selected match a spell in database
-        
-        this.cardsSelected = numCards;
+        this.selectedCards = selectedCards;
 
         // Update UI if all conditions for casting a spell have been met
-        CheckCastReady();
-
+        CheckCastReady ();
+        return spellProcessor.IsSpellComplete (selectedCards);
         // Let caller know if card selection conditions have been met
-        return this.cardsSelected == cardsRequired;
     }
 
     void CheckCastReady () {
-        castButton.SetReady(targets.Count != 0 && cardsSelected == cardsRequired);
+        castButton.SetReady (targets.Count != 0 && selectedCards.Count == cardsRequired);
     }
 
-    public void ExecuteSpell() {
-        // TODO: Apply the spell effects on the target
+    public void ExecuteSpell () {
+        spellProcessor.CastSpell(selectedCards, targets);
     }
 }

--- a/Assets/Scripts/CombatManager.cs
+++ b/Assets/Scripts/CombatManager.cs
@@ -64,6 +64,16 @@ public class CombatManager : MonoBehaviour {
     }
 
     public void ExecuteSpell () {
-        spellProcessor.CastSpell(selectedCards, targets);
+        // Compiling a list of all creatures that have died after the spell
+        List<CreatureController> targetsToRemove = new List<CreatureController> ();
+        spellProcessor.CastSpell (selectedCards, targets);
+        foreach (CreatureController creature in targets) {
+            if (creature.isCreatureDead ()) {
+                creature.DestroyCreature ();
+                targetsToRemove.Add (creature);
+            }
+        }
+        // Requires a predicate for RemoveAll call so I'm just using a lambda expression
+        targets.RemoveAll (target => targetsToRemove.Contains (target));
     }
 }

--- a/Assets/Scripts/CreatureController.cs
+++ b/Assets/Scripts/CreatureController.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 
 public class CreatureController : MonoBehaviour {
-    public HealthbarController healthbarController;
+    HealthbarController healthbarController;
 
     public string characterName;
 
@@ -18,19 +18,22 @@ public class CreatureController : MonoBehaviour {
             if (t.name == "Name") {
                 t.gameObject.GetComponent<TextMesh> ().text = characterName;
             }
+            if (t.name == "HealthBar") {
+                healthbarController = t.gameObject.GetComponent<HealthbarController> ();
+            }
         }
     }
 
     void OnMouseUp () {
-        combatManager.HandleCreatureClick(this);
+        combatManager.HandleCreatureClick (this);
     }
 
-    public void SetTargetingArrowDisplay(bool shouldDisplay) {
-        targetingArrow.SetActive(shouldDisplay);
+    public void SetTargetingArrowDisplay (bool shouldDisplay) {
+        targetingArrow.SetActive (shouldDisplay);
     }
 
     // Deducts raw damage from current hp and proportionately scales down the hp bar.  This will be the main method used for visual health updates
-    void TakeDamage (float rawDamage) {
+    public void TakeDamage (float rawDamage) {
         healthbarController.DecreaseHealth (rawDamage / hp);
         hp -= rawDamage;
         // Check to see if character has died

--- a/Assets/Scripts/CreatureController.cs
+++ b/Assets/Scripts/CreatureController.cs
@@ -38,8 +38,14 @@ public class CreatureController : MonoBehaviour {
         hp -= rawDamage;
         // Check to see if character has died
         // We'll just have the visual indicator for death be that the sprite disappears.
-        if (hp <= 0) {
-            Destroy (gameObject);
-        }
+    }
+
+    public bool isCreatureDead () {
+        return (hp <= 0);
+    }
+
+    public void DestroyCreature () {
+        Destroy (gameObject);
+
     }
 }

--- a/Assets/Scripts/SceneLoader.cs
+++ b/Assets/Scripts/SceneLoader.cs
@@ -3,9 +3,8 @@ using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
-public class SceneLoader : MonoBehaviour
-{
-    public void LoadScene(int destinationSceneIndex) {
-        SceneManager.LoadScene(destinationSceneIndex);
+public class SceneLoader : MonoBehaviour {
+    public void LoadScene (int destinationSceneIndex) {
+        SceneManager.LoadScene (destinationSceneIndex);
     }
 }

--- a/Assets/Scripts/Spells.meta
+++ b/Assets/Scripts/Spells.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6e421e7be28274abba4d814626fbf2bf
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/Spell.cs
+++ b/Assets/Scripts/Spells/Spell.cs
@@ -13,4 +13,6 @@ public class Spell {
     public SpellElement element;
     public SpellVerb verb;
     public SpellManner manner;
+
+
 }

--- a/Assets/Scripts/Spells/Spell.cs
+++ b/Assets/Scripts/Spells/Spell.cs
@@ -1,0 +1,16 @@
+using System;
+[Serializable]
+public class Spell {
+    // Applicable to all
+    public SpellType type;
+    // Applicable to all
+    public float amount;
+    // Applicable to cards with manner type OVER_TIME or LATER
+    public int duration;
+    // Applicable to cards with different Verb types
+    public float multiplier;
+    // These three spell types are going to be mutually exclusively filled based on what kind of card it is.  Default will be null.
+    public SpellElement element;
+    public SpellVerb verb;
+    public SpellManner manner;
+}

--- a/Assets/Scripts/Spells/Spell.cs.meta
+++ b/Assets/Scripts/Spells/Spell.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1221024ac77d64ea087ceb90a581e4d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/SpellData.meta
+++ b/Assets/Scripts/Spells/SpellData.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f3e7df75609414e508670660ce55ac64
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/SpellData/FallSpell.json
+++ b/Assets/Scripts/Spells/SpellData/FallSpell.json
@@ -1,5 +1,7 @@
-{
-    "type": 1,
+{   
+    "type": 2,
     "multiplier": 1.5,
-    "verb": 0
+    "element": 0,
+    "verb": 1,
+    "manner": 0
 }

--- a/Assets/Scripts/Spells/SpellData/FallSpell.json
+++ b/Assets/Scripts/Spells/SpellData/FallSpell.json
@@ -1,0 +1,5 @@
+{
+    "type": 1,
+    "multiplier": 1.5,
+    "verb": 0
+}

--- a/Assets/Scripts/Spells/SpellData/FallSpell.json.meta
+++ b/Assets/Scripts/Spells/SpellData/FallSpell.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: f6deac37341ed4846ad2d5ed99118cf8
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/SpellData/FireSpell.json
+++ b/Assets/Scripts/Spells/SpellData/FireSpell.json
@@ -1,6 +1,8 @@
 {
-    "type": 0,
-    "amount": 15,
+    "type": 1,
+    "amount": 15.0,
     "duration": 0,
-    "element": 0
+    "element": 1,
+    "verb": 0,
+    "manner": 0
 }

--- a/Assets/Scripts/Spells/SpellData/FireSpell.json
+++ b/Assets/Scripts/Spells/SpellData/FireSpell.json
@@ -1,0 +1,6 @@
+{
+    "type": 0,
+    "amount": 15,
+    "duration": 0,
+    "element": 0
+}

--- a/Assets/Scripts/Spells/SpellData/FireSpell.json.meta
+++ b/Assets/Scripts/Spells/SpellData/FireSpell.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: e32a8e9f962054630b047f48b7b33f70
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/SpellData/ImmediatelySpell.json
+++ b/Assets/Scripts/Spells/SpellData/ImmediatelySpell.json
@@ -1,0 +1,7 @@
+{
+    "type": 3,
+    "multiplier": 1.5,
+    "element": 0,
+    "verb": 0,
+    "manner": 1
+}

--- a/Assets/Scripts/Spells/SpellData/ImmediatelySpell.json.meta
+++ b/Assets/Scripts/Spells/SpellData/ImmediatelySpell.json.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 585212f3f2ea24b3d88d56d20fbd1913
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/SpellElement.cs
+++ b/Assets/Scripts/Spells/SpellElement.cs
@@ -1,5 +1,6 @@
 public enum SpellElement{
-    FIRE = 0,
-    WATER = 1,
-    FROST = 2,
+    NOT_AVAILABLE = 0,
+    FIRE = 1,
+    WATER = 2,
+    FROST = 3,
 }

--- a/Assets/Scripts/Spells/SpellElement.cs
+++ b/Assets/Scripts/Spells/SpellElement.cs
@@ -1,0 +1,5 @@
+public enum SpellElement{
+    FIRE = 0,
+    WATER = 1,
+    FROST = 2,
+}

--- a/Assets/Scripts/Spells/SpellElement.cs.meta
+++ b/Assets/Scripts/Spells/SpellElement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cce2bc151ec4c4746872bf94c0486f42
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/SpellManner.cs
+++ b/Assets/Scripts/Spells/SpellManner.cs
@@ -1,5 +1,6 @@
 public enum SpellManner{
-    IMMEDIATELY = 0,
-    OVER_TIME = 1,
-    LATER = 2,
+    NOT_AVAILABLE = 0,
+    IMMEDIATELY = 1,
+    OVER_TIME = 2,
+    LATER = 3,
 }

--- a/Assets/Scripts/Spells/SpellManner.cs
+++ b/Assets/Scripts/Spells/SpellManner.cs
@@ -1,0 +1,5 @@
+public enum SpellManner{
+    IMMEDIATELY = 0,
+    OVER_TIME = 1,
+    LATER = 2,
+}

--- a/Assets/Scripts/Spells/SpellManner.cs.meta
+++ b/Assets/Scripts/Spells/SpellManner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8a670656efd5d4aa8b5e5f74d60bbe60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/SpellProcessor.cs
+++ b/Assets/Scripts/Spells/SpellProcessor.cs
@@ -1,9 +1,27 @@
 using System.Collections.Generic;
 using UnityEngine;
 public class SpellProcessor {
+    bool hasElement, hasVerb, hasManner;
 
     public bool IsSpellComplete (List<CardController> selectedCards) {
-        return true;
+        resetSpell ();
+        foreach (CardController selectedCard in selectedCards) {
+            switch (selectedCard.spell.type) {
+                case SpellType.ELEMENT:
+                    hasElement = true;
+                    break;
+                case SpellType.VERB:
+                    hasVerb = true;
+                    break;
+                case SpellType.MANNER:
+                    hasManner = true;
+                    break;
+                default:
+                    break;
+            }
+        }
+
+        return (hasElement && hasVerb && hasManner);
     }
 
     public void CastSpell (List<CardController> selectedCards, List<CreatureController> targets) {
@@ -21,9 +39,14 @@ public class SpellProcessor {
                     break;
             }
         }
-        Debug.Log ("Current damage amount: " + multiplier * damage);
         foreach (CreatureController target in targets) {
             target.TakeDamage (multiplier == 0 ? damage : multiplier * damage);
         }
+    }
+
+    void resetSpell () {
+        this.hasElement = false;
+        this.hasVerb = false;
+        this.hasManner = false;
     }
 }

--- a/Assets/Scripts/Spells/SpellProcessor.cs
+++ b/Assets/Scripts/Spells/SpellProcessor.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using UnityEngine;
+public class SpellProcessor {
+
+    public bool IsSpellComplete (List<CardController> selectedCards) {
+        return true;
+    }
+
+    public void CastSpell (List<CardController> selectedCards, List<CreatureController> targets) {
+        float damage = 0;
+        float multiplier = 0;
+        foreach (CardController selectedCard in selectedCards) {
+            switch (selectedCard.spell.type) {
+                // Only element will have an amount
+                case SpellType.ELEMENT:
+                    damage += selectedCard.spell.amount;
+                    break;
+                    // Manner or Verb can have multipliers for now
+                default:
+                    multiplier += selectedCard.spell.multiplier;
+                    break;
+            }
+        }
+        Debug.Log ("Current damage amount: " + multiplier * damage);
+        foreach (CreatureController target in targets) {
+            target.TakeDamage (multiplier == 0 ? damage : multiplier * damage);
+        }
+    }
+}

--- a/Assets/Scripts/Spells/SpellProcessor.cs.meta
+++ b/Assets/Scripts/Spells/SpellProcessor.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 194e243a1d9ad474ca09bd353ee8133b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/SpellTypes.cs
+++ b/Assets/Scripts/Spells/SpellTypes.cs
@@ -1,0 +1,5 @@
+public enum SpellType{
+    ELEMENT = 0,
+    VERB = 1,
+    MANNER = 2,
+}

--- a/Assets/Scripts/Spells/SpellTypes.cs
+++ b/Assets/Scripts/Spells/SpellTypes.cs
@@ -1,5 +1,6 @@
-public enum SpellType{
-    ELEMENT = 0,
-    VERB = 1,
-    MANNER = 2,
+public enum SpellType {
+    NOT_AVAILABLE = 0,
+    ELEMENT = 1,
+    VERB = 2,
+    MANNER = 3,
 }

--- a/Assets/Scripts/Spells/SpellTypes.cs.meta
+++ b/Assets/Scripts/Spells/SpellTypes.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 362cf09897b55486097bfe5d5cf35a49
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Spells/SpellVerb.cs
+++ b/Assets/Scripts/Spells/SpellVerb.cs
@@ -1,0 +1,5 @@
+public enum SpellVerb{
+    FALL = 0,
+    ENCOMPASS = 1,
+    PIERCE = 2,
+}

--- a/Assets/Scripts/Spells/SpellVerb.cs
+++ b/Assets/Scripts/Spells/SpellVerb.cs
@@ -1,5 +1,6 @@
 public enum SpellVerb{
-    FALL = 0,
-    ENCOMPASS = 1,
-    PIERCE = 2,
+    NOT_AVAILABLE = 0,
+    FALL = 1,
+    ENCOMPASS = 2,
+    PIERCE = 3,
 }

--- a/Assets/Scripts/Spells/SpellVerb.cs.meta
+++ b/Assets/Scripts/Spells/SpellVerb.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 40399e3f774d045d6bc1208454401955
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
1. Fixed bug where deselecting a card would not change to the appropriate card color.

2. Added Spell Library of 3 sample Spell JSON objects as well as the corresponding classes and processors for deserialization.

3. Added SpellProcessor to be the centralized spell validating engine.  Right now things are pretty hard coded, will explore grammar after this is merged in a separate PR.

4. General refactoring that's up for discussion.

NOTE:
Right now I have the indexes of the cards on screen changing to a ready color independent of whether or not targets have been selected yet.  Is this what we want or do we want to have the indexes of cards only change to red when the cast button is also ready to cast?